### PR TITLE
fix: dockerfile env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@ FROM node:20-bookworm-slim
 COPY . /metrics
 WORKDIR /metrics
 
+# Environment variables
+ENV PUPPETEER_SKIP_DOWNLOAD 1
+ENV PUPPETEER_EXECUTABLE_PATH "google-chrome-stable"
+ENV PUPPETEER_BROWSER_PATH "google-chrome-stable"
+
 # Setup
 RUN chmod +x /metrics/source/app/action/index.mjs \
   # Install latest chrome dev package, fonts to support major charsets and skip chromium download on puppeteer install
@@ -29,10 +34,6 @@ RUN chmod +x /metrics/source/app/action/index.mjs \
   # Install node modules and rebuild indexes
   && npm ci \
   && npm run build
-
-# Environment variables
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
-ENV PUPPETEER_BROWSER_PATH "google-chrome-stable"
 
 # Execute GitHub action
 ENTRYPOINT node /metrics/source/app/action/index.mjs


### PR DESCRIPTION
the action was hanging on `npm ci` part of the dockerfile due to the puppeteer postinstall script. correcting the environment variables to properly skip it fixes this and the metric scripts themselves always start the puppeteer instance with whatever is in PUPPETEER_BROWSER_PATH. i can see others who were experiencing the same issue of the action hanging indefinitely in https://github.com/lowlighter/metrics/issues/1706

an example of where this would happen: https://github.com/yobson1/yobson1/actions/runs/16111678701/job/45456430680