### PR TITLE
fix achievement plugin

### DIFF
--- a/source/app/metrics/index.mjs
+++ b/source/app/metrics/index.mjs
@@ -213,7 +213,7 @@ export default async function metrics({login, q}, {graphql, rest, plugins, conf,
       catch (error) {
         console.debug(`metrics/compute/${login} > failed to import libxmljs2 (${error}), ignoring SVG verification`)
       }
-      if (!libxmljs) {
+      if (libxmljs) {
         const parsed = libxmljs.parseXml(rendered)
         if (parsed.errors.length)
           throw new Error(`Malformed SVG : \n${parsed.errors.join("\n")}`)

--- a/source/plugins/achievements/list/users.mjs
+++ b/source/plugins/achievements/list/users.mjs
@@ -55,8 +55,8 @@ export default async function({list, login, data, computed, imports, graphql, qu
 
   //Manager
   {
-    const value = user.projects.totalCount
-    const unlock = user.projects.nodes?.shift()
+    const value = user.projectsV2.totalCount
+    const unlock = user.projectsV2.nodes?.shift()
 
     list.push({
       title: "Manager",

--- a/source/plugins/achievements/list/users.mjs
+++ b/source/plugins/achievements/list/users.mjs
@@ -55,8 +55,8 @@ export default async function({list, login, data, computed, imports, graphql, qu
 
   //Manager
   {
-    const value = user.projectsV2.totalCount
-    const unlock = user.projectsV2.nodes?.shift()
+    const value = user.projects.totalCount
+    const unlock = user.projects.nodes?.shift()
 
     list.push({
       title: "Manager",

--- a/source/plugins/achievements/queries/achievements.graphql
+++ b/source/plugins/achievements/queries/achievements.graphql
@@ -47,7 +47,7 @@ query AchievementsDefault {
         totalCount
       }
     }
-    projects: projectsV2(first: 1, orderBy: {field: CREATED_AT, direction: ASC}) {
+    projectsV2: projectsV2(first: 1, orderBy: {field: CREATED_AT, direction: ASC}) {
       totalCount
       #nodes { This requires additional scopes :/
       #  name

--- a/tests/mocks/api/github/graphql/achievements.default.mjs
+++ b/tests/mocks/api/github/graphql/achievements.default.mjs
@@ -49,7 +49,7 @@ export default function({faker, query, login = faker.internet.userName()}) {
           totalCount: faker.number.int(1000),
         },
       },
-      projects: {totalCount: faker.number.int(100)},
+      projectsV2: {totalCount: faker.number.int(100)},
       packages: {totalCount: faker.number.int(100)},
       organizations: {nodes: [], totalCount: faker.number.int(5)},
       gists: {


### PR DESCRIPTION
https://github.com/gh-metrics/metrics/blob/master/source/plugins/achievements/list/users.mjs#L58

The GraphQL query aliases `projectsV2` as `projects`, so `user.projectsV2` was always undefined.

confirm fixed on:

https://github.com/phamleduy04/phamleduy04/actions/runs/26466960667/job/77929752558

Before:

Error logs
```
metrics/compute/phamleduy04 > 1 errors !
[
  {
    name: 'achievements',
    result: {
      error: {
        message: 'Unexpected error',
        instance: TypeError: Cannot read properties of undefined (reading 'totalCount')
            at Module.default (file:///Users/dui/Documents/GitHub/metrics/source/plugins/achievements/list/users.mjs:58:35)
            at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
            at async Object.default [as achievements] (file:///Users/dui/Documents/GitHub/metrics/source/plugins/achievements/index.mjs:18:5)
            at async file:///Users/dui/Documents/GitHub/metrics/source/plugins/core/index.mjs:67:30
            at async Promise.all (index 0)
            at async metrics (file:///Users/dui/Documents/GitHub/metrics/source/app/metrics/index.mjs:81:22)
            at async file:///Users/dui/Documents/GitHub/metrics/source/app/web/instance.mjs:486:34
      }
    }
  }
```
