### PR TITLE
fix: fetch full pull request data in activity plugin

### DIFF
--- a/source/plugins/activity/index.mjs
+++ b/source/plugins/activity/index.mjs
@@ -140,14 +140,18 @@ export default async function({login, data, rest, q, account, imports}, {enabled
             case "PullRequestEvent": {
               if (!["opened", "closed"].includes(payload.action))
                 return null
-              const {action, pull_request: {user: {login: user}, title, number, body: content, additions: added, deletions: deleted, changed_files: changed, merged}} = payload
+              const {action, pull_request: {number}} = payload
+              const [owner, repoName] = repo.split("/")
+              const {data: {user: {login: user}, title, body: content, additions: added, deletions: deleted, changed_files: changed, merged}} = await rest.pulls.get({owner, repo: repoName, pull_number: number})
               if (!imports.filters.text(user, ignored))
                 return null
               return {type: customType, actor, timestamp, repo, action: (action === "closed") && (merged) ? "merged" : action, user, title, number, content: await imports.markdown(content, {mode: markdown, codelines}), lines: {added, deleted}, files: {changed}}
             }
             //Reviewed a pull request
             case "PullRequestReviewEvent": {
-              const {review: {state: review}, pull_request: {user: {login: user}, number, title}} = payload
+              const {review: {state: review}, pull_request: {number}} = payload
+              const [owner, repoName] = repo.split("/")
+              const {data: {user: {login: user}, title}} = await rest.pulls.get({owner, repo: repoName, pull_number: number})
               if (!imports.filters.text(user, ignored))
                 return null
               return {type: customType, actor, timestamp, repo, review, user, number, title}
@@ -156,7 +160,9 @@ export default async function({login, data, rest, q, account, imports}, {enabled
             case "PullRequestReviewCommentEvent": {
               if (!["created"].includes(payload.action))
                 return null
-              const {pull_request: {user: {login: user}, title, number}, comment: {body: content, performed_via_github_app: mobile}} = payload
+              const {pull_request: {number}, comment: {body: content, performed_via_github_app: mobile}} = payload
+              const [owner, repoName] = repo.split("/")
+              const {data: {user: {login: user}, title}} = await rest.pulls.get({owner, repo: repoName, pull_number: number})
               if (!imports.filters.text(user, ignored))
                 return null
               return {type: customType, on: "pr", actor, timestamp, repo, content: await imports.markdown(content, {mode: markdown, codelines}), user, mobile, number, title}

--- a/tests/mocks/api/github/rest/activity/listEventsForAuthenticatedUser.mjs
+++ b/tests/mocks/api/github/rest/activity/listEventsForAuthenticatedUser.mjs
@@ -50,12 +50,7 @@ export default async function({faker}, target, that, [{username: login, page, pe
             body: faker.lorem.paragraph(),
           },
           pull_request: {
-            title: faker.lorem.sentence(),
             number: 1,
-            user: {
-              login: faker.internet.userName(),
-            },
-            body: "",
           },
         },
         created_at: faker.date.recent({days: 7}),
@@ -180,10 +175,6 @@ export default async function({faker}, target, that, [{username: login, page, pe
             state: "open",
             number: 4,
             locked: false,
-            title: faker.lorem.sentence(),
-            user: {
-              login: faker.internet.userName(),
-            },
           },
         },
         created_at: faker.date.recent({days: 7}),
@@ -295,14 +286,8 @@ export default async function({faker}, target, that, [{username: login, page, pe
           action: faker.helpers.arrayElement(["opened", "closed"]),
           number: 5,
           pull_request: {
-            user: {
-              login,
-            },
             state: "open",
-            title: faker.lorem.sentence(),
-            additions: faker.number.int(1000),
-            deletions: faker.number.int(1000),
-            changed_files: faker.number.int(10),
+            number: 5,
           },
         },
         created_at: faker.date.recent({days: 7}),

--- a/tests/mocks/api/github/rest/pulls/get.mjs
+++ b/tests/mocks/api/github/rest/pulls/get.mjs
@@ -1,0 +1,27 @@
+/**Mocked data */
+export default async function({faker}, target, that, [{owner, repo, pull_number}]) {
+  console.debug("metrics/compute/mocks > mocking rest api result > rest.pulls.get")
+  return ({
+    status: 200,
+    url: `https://api.github.com/repos/${owner}/${repo}/pulls/${pull_number}`,
+    headers: {
+      server: "GitHub.com",
+      status: "200 OK",
+      "x-oauth-scopes": "repo",
+    },
+    data: {
+      id: faker.number.int(100000),
+      number: pull_number,
+      title: faker.lorem.sentence(),
+      body: faker.lorem.paragraph(),
+      user: {
+        login: faker.internet.userName(),
+      },
+      state: "open",
+      merged: faker.datatype.boolean(),
+      additions: faker.number.int(1000),
+      deletions: faker.number.int(1000),
+      changed_files: faker.number.int(10),
+    },
+  })
+}


### PR DESCRIPTION
## Description

Fixes #80.

GitHub's Events API now sends a truncated `pull_request` object (only `base`, `head`, `id`, `number`, `url`) on `PullRequestEvent`, `PullRequestReviewEvent`, and `PullRequestReviewCommentEvent`. The `activity` plugin destructured `user`, `title`, and `body` directly off that object, so it threw `Cannot read properties of undefined (reading 'login')` whenever one of these events was processed.

This mirrors the earlier fix for `PushEvent`'s truncated `commits` (which uses `compareCommitsWithBasehead`): the three affected cases now call `rest.pulls.get({owner, repo, pull_number})` to fetch the full PR data instead of relying on the event payload.

## Changes

- `source/plugins/activity/index.mjs`: fetch `user`/`title`/`body`/stats via `rest.pulls.get` for `PullRequestEvent`, `PullRequestReviewEvent`, `PullRequestReviewCommentEvent`
- `tests/mocks/api/github/rest/pulls/get.mjs`: new mock for `rest.pulls.get`
- `tests/mocks/api/github/rest/activity/listEventsForAuthenticatedUser.mjs`: truncated the `pull_request` fixtures to match GitHub's actual (short) payload shape, so the existing activity test actually exercises this bug

## Test plan

- [x] `jest --runInBand` activity/markdown template cases pass with the truncated fixture
