### PR TITLE
ci: finish reliably under branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,37 +17,11 @@ jobs:
     permissions:
       contents: read # Check out and test the repository.
 
-  # Update plugins and template indexes, along with README.md
-  update-indexes:
-    name: Publish rebuilt metrics indexes
-    runs-on: ubuntu-latest
-    needs: [build-test-analyze]
-    permissions:
-      contents: write # Commit and push regenerated indexes.
-    steps:
-      # zizmor: ignore[artipacked] Credentials are required to publish regenerated files.
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
-        with:
-          persist-credentials: true
-          fetch-depth: 0
-          ref: master
-      - name: Setup NodeJS
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6.0.0
-        with:
-          node-version: 20
-          cache: "npm"
-      - name: Setup metrics
-        run: npm ci --ignore-scripts --no-audit --no-fund
-      - name: Publish rebuild metrics indexes
-        # zizmor: ignore[use-trusted-publishing] This publishes generated files to Git, not an npm package.
-        run: npm run build -- publish
-
   # Rebase main branch on master
   update-main:
     name: Rebase main on master
     runs-on: ubuntu-latest
-    needs: [update-indexes]
+    needs: [build-test-analyze]
     permissions:
       contents: write # Merge master into and push the main branch.
     steps:
@@ -70,7 +44,7 @@ jobs:
   docker-master:
     name: Publish master to GitHub registry
     runs-on: ubuntu-latest
-    needs: [update-indexes]
+    needs: [build-test-analyze]
     permissions:
       contents: read # Build the image from repository contents.
       packages: write # Publish master and beta container images.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
   lint:
     name: Lint code
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
@@ -32,15 +33,29 @@ jobs:
         run: npm run test-contrib
       - name: Run linter
         run: npm run linter
+      - name: Verify generated files
+        run: |
+          npm run build
+          git diff --exit-code
+          test -z "$(git ls-files --others --exclude-standard)"
       - name: Format code
         run: |
           mkdir -v -p /home/runner/.cache/dprint/cache
           npm exec dprint check -- --config .github/config/dprint.json
 
-  # Build docker image from branch and run tests
-  build:
-    name: Build and test
+  # Build the Docker image and run independent test suites in parallel
+  test:
+    name: Test metrics (${{ matrix.suite }})
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: action
+            pattern: ^(GitHub Action|plugins_errors_fatal)
+          - suite: web
+            pattern: ^Web instance
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
@@ -53,4 +68,20 @@ jobs:
       - name: Run tests
         env:
           GIT_REF: ${{ github.head_ref || 'master' }}
-        run: docker run --rm --entrypoint="" gh-metrics/metrics:$(echo $GIT_REF | sed 's/[^a-z]/-/g') npm run test-metrics
+          TEST_PATTERN: ${{ matrix.pattern }}
+        run: docker run --rm --entrypoint="" gh-metrics/metrics:$(echo $GIT_REF | sed 's/[^a-z]/-/g') npm run test-metrics -- --testNamePattern "$TEST_PATTERN"
+
+  # Preserve the required status-check name while aggregating the test shards
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    if: ${{ always() }}
+    steps:
+      - name: Check lint and test results
+        env:
+          LINT_RESULT: ${{ needs.lint.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          test "$LINT_RESULT" = "success"
+          test "$TEST_RESULT" = "success"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Generate metrics that can be embedded everywhere, including your GitHub profile 
   </tr>
   <tr>
     <th colspan="2" align="center">
-      <h3><a href="/README.md#-plugins">🧩 Customizable with 47 plugins and 335 options!</a></h3>
+      <h3><a href="/README.md#-plugins">🧩 Customizable with 47 plugins and 336 options!</a></h3>
     </th>
   </tr>
   <tr>

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: Include forks
     default: <default-value>
 
+  repositories_owned:
+    description: Include your own repositories in the "Contributed to X repositories" count
+    default: <default-value>
+
   repositories_affiliations:
     description: Repositories affiliations
     default: <default-value>

--- a/source/plugins/base/README.md
+++ b/source/plugins/base/README.md
@@ -147,6 +147,17 @@ This setting may not be supported by all plugins.</p>
 <b>default:</b> no<br></td>
   </tr>
   <tr>
+    <td nowrap="nowrap"><h4><code>repositories_owned</code></h4></td>
+    <td rowspan="2"><p>Include your own repositories in the &quot;Contributed to X repositories&quot; count</p>
+<img width="900" height="1" alt=""></td>
+  </tr>
+  <tr>
+    <td nowrap="nowrap">✨ On <code>master</code>/<code>main</code><br>
+<b>type:</b> <code>boolean</code>
+<br>
+<b>default:</b> yes<br></td>
+  </tr>
+  <tr>
     <td nowrap="nowrap"><h4><code>repositories_affiliations</code></h4></td>
     <td rowspan="2"><p>Repositories affiliations</p>
 <ul>

--- a/source/plugins/core/README.md
+++ b/source/plugins/core/README.md
@@ -1134,7 +1134,7 @@ This option has no effects on forks (images will always be rebuilt from Dockerfi
   <tr>
     <td nowrap="nowrap"><h4><code>plugins_errors_fatal</code></h4></td>
     <td rowspan="2"><p>Fatal plugin errors</p>
-<p>When enabled, the job will fail and output will not be committed in case of plugin errors, else errors will be handled gracefully and displayed in the generated output</p>
+<p>When enabled, the job will fail and output will not be committed in case of plugin errors, otherwise errors will be handled gracefully and displayed in the generated output</p>
 <img width="900" height="1" alt=""></td>
   </tr>
   <tr>

--- a/tests/ci.test.js
+++ b/tests/ci.test.js
@@ -5,22 +5,6 @@ const git = require("simple-git")(path.join(__dirname, ".."))
 //Edited files list
 const diff = async () => (await git.diff(["origin/master...", "--name-status"])).split("\n").map(x => x.trim()).filter(x => /^M\s+/.test(x)).map(x => x.replace(/^M\s+/, ""))
 
-//File changes
-describe("Check file changes (checkout your files if needed)", () => {
-  describe("Auto-generated files were not modified", () =>
-    void test.each([
-      "README.md",
-      "source/plugins/README.md",
-      "source/plugins/community/README.md",
-      "source/templates/README.md",
-      "action.yml",
-      "settings.example.json",
-      "tests/cases/*",
-      ".github/workflows/examples.yml",
-      ".github/readme/partials/documentation/compatibility.md",
-    ])("%s", async file => expect((await diff()).includes(file)).toBe(false)))
-})
-
 //Template changes
 describe("Check template changes", () => {
   test("Use community templates instead (see https://github.com/gh-metrics/metrics/tree/master/source/templates/community)", async () => void expect((await diff()).filter(edited => /^sources[/]templates[/]/.test(edited) && /^source[/]templates[/](?:classic|terminal|markdown|repository|community)[/][\s\S]*$/.test(edited)).length).toBe(0))


### PR DESCRIPTION
## Summary
- split the serial metrics suite into parallel action and web shards while preserving the required `Build and test` check
- cap lint and test jobs so regressions cannot consume the six-hour Actions limit
- verify generated outputs in pull requests instead of pushing a new, unchecked commit directly to protected `master`
- commit the generated outputs currently missing from `master`

## Diagnosis
The latest CI run was not blocked in `npm ci`: the script-free install completed in 7 seconds. The test job then ran 331 Jest cases serially for about 36 minutes (roughly 22 minutes of action tests and 14 minutes of web tests). Afterward, index publication failed with GH013 because the workflow tried to push a newly generated commit directly to `master`, where `Build and test` and `Lint code` are required.

## Validation
- `npm run build` followed by a clean generated-output diff
- `npm run test-contrib`
- `npm run linter`
- `npm exec dprint check -- --config .github/config/dprint.json`
- workflow YAML parse
- `git diff --check`

The full Docker suites are left to this PR's matrix jobs; those are the long-running checks this change parallelizes.